### PR TITLE
fix(debian): ensure unzip is available when installing

### DIFF
--- a/src/sh/install/debian.sh
+++ b/src/sh/install/debian.sh
@@ -4,7 +4,7 @@ set -e
 
 __numonic_install_debian() {
 	sudo_cmd=$(command -v sudo || printf '')
-	packages="git gnupg jq"
+	packages="git gnupg jq unzip"
 
 	print-success "debian: updating software repositories..."
 	"${sudo_cmd}" apt update --yes

--- a/src/sh/install/wsl.sh
+++ b/src/sh/install/wsl.sh
@@ -35,6 +35,11 @@ fi
 # make sure the font dir exists
 mkdir -p "${font_dir}" 1>/dev/null
 
+# ensure unzip exists
+if ! command -v unzip >/dev/null 2>&1; then
+	sudo apt install -y unzip
+fi
+
 # extract fira code
 unzip "${temp_dir}"/FiraCode.zip 'Fira*Windows*.ttf' -d "${font_dir}" 1>/dev/null
 

--- a/src/sh/install/wsl.sh
+++ b/src/sh/install/wsl.sh
@@ -35,11 +35,6 @@ fi
 # make sure the font dir exists
 mkdir -p "${font_dir}" 1>/dev/null
 
-# ensure unzip exists
-if ! command -v unzip >/dev/null 2>&1; then
-	sudo apt install -y unzip
-fi
-
 # extract fira code
 unzip "${temp_dir}"/FiraCode.zip 'Fira*Windows*.ttf' -d "${font_dir}" 1>/dev/null
 


### PR DESCRIPTION
when installing a nerd font we need to unzip the file. 
unzip is not installed by default in wsl. 

this may also effect other distros