### PR TITLE
fix(wsl): remove appending windows path to wsl path

### DIFF
--- a/src/sh/install/wsl.sh
+++ b/src/sh/install/wsl.sh
@@ -48,7 +48,11 @@ if [ ! -f "/etc/wsl.conf" ]; then
 		[automount]
 		enabled = true
 		options = "metadata"
-	EOT
+
+		[interop]
+		enabled = true
+		appendWindowsPath = false
+		EOT
 fi
 
 # determine if ssh remoting is configured


### PR DESCRIPTION
If you have the same applications installed on windows and on the path that numonic uses there will be errors since you are using a windows app in a linux env. 

This showed up for me since i had NPM installed on windows and numonic be default would try to add tab completion on start up resulting in the error `/usr/local/env 'bash\r' file or directory does not exist` not something you want to see when you first load up your brand new shell or any other time for that matter 😉 