### PR TITLE
fix: rm flags for aws/dotnet/gcp install scripts

### DIFF
--- a/src/sh/scripts/install-azure
+++ b/src/sh/scripts/install-azure
@@ -16,7 +16,7 @@ __numonic_install_azure() {
 				;;
 			-f|--force)
 				if [ -d "${install_dir}" ]; then
-					rm --recursive --force "${install_dir}"
+					rm -rf "${install_dir}"
 				fi
 
 				if command -v az 1>/dev/null 2>&1; then

--- a/src/sh/scripts/install-dotnet
+++ b/src/sh/scripts/install-dotnet
@@ -33,11 +33,11 @@ __numonic_install_dotnet() {
 				;;
 			-f|--force)
 				if [ -d "${install_dir}" ]; then
-					rm --recursive --force "${install_dir}"
+					rm -rf "${install_dir}"
 				fi
 
 				if [ -d "${HOME}/dotnet" ]; then
-					rm --recursive --force "${HOME}/dotnet"
+					rm -rf "${HOME}/dotnet"
 				fi
 
 				if command -v dotnet 1>/dev/null 2>&1; then

--- a/src/sh/scripts/install-gcloud
+++ b/src/sh/scripts/install-gcloud
@@ -79,7 +79,7 @@ __numonic_install_gcloud() {
 			--directory="${install_dir}" 1>/dev/null
 
 		# remove the temp directory
-		rm --recursive --force "${temp}"
+		rm -rf "${temp}"
 
 		"${install_dir}"/install.sh \
 			--command-completion false \


### PR DESCRIPTION
Change `rm --recursive --force` to `rm -rf` in `install-aws`, `install-dotnet`, `install-gcloud` scripts. 

Closes #17